### PR TITLE
Fix testAlBufferDataintintByteBufferintint ERROR java.io.IOException:

### DIFF
--- a/src/test/com/jogamp/openal/test/junit/ALTest.java
+++ b/src/test/com/jogamp/openal/test/junit/ALTest.java
@@ -13,6 +13,7 @@ import com.jogamp.openal.ALCdevice;
 import com.jogamp.openal.ALFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.BufferedInputStream;
 
 import javax.sound.sampled.UnsupportedAudioFileException;
 
@@ -383,6 +384,8 @@ public class ALTest {
 
     private WAVData loadTestWAV() throws IOException, UnsupportedAudioFileException {
         InputStream resource = ResourceLocation.getInputStream(TEST_FILE, true);
-        return WAVLoader.loadFromStream(resource);
+        // Add buffer for mark/reset support as required by getAudioInputStream.
+        InputStream bufferResource = new BufferedInputStream(resource); 
+        return WAVLoader.loadFromStream(bufferResource);
     }
 }


### PR DESCRIPTION
 mark/reset not supported.

```
[junit] Testcase: testAlBufferDataintintByteBufferintint took 0,021 sec
[junit]     Caused an ERROR
[junit] mark/reset not supported
[junit] java.io.IOException: mark/reset not supported
[junit]     at java.util.zip.InflaterInputStream.reset(InflaterInputStream.java:286)
[junit]     at java.io.FilterInputStream.reset(FilterInputStream.java:217)
[junit]     at com.sun.media.sound.SoftMidiAudioFileReader.getAudioInputStream(SoftMidiAudioFileReader.java:135)
[junit]     at javax.sound.sampled.AudioSystem.getAudioInputStream(AudioSystem.java:1111)
[junit]     at com.jogamp.openal.util.WAVLoader.loadFromStream(WAVLoader.java:87)
[junit]     at com.jogamp.openal.test.junit.ALTest.loadTestWAV(ALTest.java:386)
[junit]     at com.jogamp.openal.test.junit.ALTest.testAlBufferDataintintByteBufferintint(ALTest.java:281)
```

Signed-off-by: Xerxes Rånby xerxes@zafena.se
