### PR TITLE
Adding method for retrieving the playing state of a Source.

### DIFF
--- a/src/java/com/jogamp/openal/sound3d/Source.java
+++ b/src/java/com/jogamp/openal/sound3d/Source.java
@@ -89,6 +89,17 @@ public final class Source {
     }
 
     /**
+     * Determines whether or not this source is playing.
+     *
+     * @return {@code true} if this source is playing.
+     */
+    public boolean isPlaying() {
+        int[] result = new int[1];
+        al.alGetSourcei(sourceID, AL.AL_SOURCE_STATE, result, 0);
+        return result[0] == AL.AL_PLAYING;
+    }
+
+    /**
      * Sets the pitch of the audio on this source. The pitch may be modified
      * without altering the playback speed of the audio.
      *


### PR DESCRIPTION
In order to determine if a source is playing or not, it is necessary to retrieve the source state using the source ID. Since the source ID is not retrievable outside the Source itself, it is necessary for the Source to provide the API to retrieve the playing state.
