### PR TITLE
Adding support for Android x86 platforms

### DIFF
--- a/make/build.xml
+++ b/make/build.xml
@@ -481,7 +481,24 @@
         <copy file="${build}/jar/joal-natives-${os.and.arch}.jar" tofile="${build}/jar/joal-android-natives-${os.and.arch}.jar"/>
     </target>
 
-    <target name="c.build.openal.soft.android" if="isAndroid" unless="c.build.openal.soft.done">
+    <target name="c.build.openal.soft.android.x86" if="isAndroidX86" unless="c.build.openal.soft.done">
+        <property name="c.build.openal.soft.done" value="true" />
+        <mkdir dir="${build}/openal-soft" />
+        <exec dir="${build}/openal-soft" executable="cmake" logError="true" failonerror="false" failifexecutionfails="false">
+            <env key="PATH" value="${env.PATH_VANILLA}"/>
+            <env key="ANDROID_TOOLCHAIN_VERSION" value="${env.GCC_VERSION}"/>
+            <env key="ANDROID_NDK" value="${env.NDK_ROOT}"/>
+            <arg value="../../openal-soft"/>
+            <arg value="-DCMAKE_TOOLCHAIN_FILE=../../openal-soft/cmake/toolchain.android.cmake"/>
+            <arg value="-DNDK_CPU_X86=1"/>
+            <arg value="-DANDROID_API_LEVEL=${android.version}"/>
+            <arg value="-DALSOFT_CPUEXT_SSE4_1=0"/>
+            <arg value="-DALSOFT_CPUEXT_NEON=0"/>
+        </exec>
+        <exec dir="${build}/openal-soft" executable="make" logError="true" failonerror="false" failifexecutionfails="false" />
+    </target>
+
+    <target name="c.build.openal.soft.android.armv6" if="isAndroidARMv6" unless="c.build.openal.soft.done">
         <property name="c.build.openal.soft.done" value="true" />
         <mkdir dir="${build}/openal-soft" />
         <exec dir="${build}/openal-soft" executable="cmake" logError="true" failonerror="false" failifexecutionfails="false">
@@ -494,6 +511,8 @@
         </exec>
         <exec dir="${build}/openal-soft" executable="make" logError="true" failonerror="false" failifexecutionfails="false" />
     </target>
+
+    <target name="c.build.openal.soft.android" if="isAndroid" depends="c.build.openal.soft.android.x86,c.build.openal.soft.android.armv6" />
 
     <target name="c.build.openal.soft.windows" if="isWindows" unless="c.build.openal.soft.done">
         <property name="c.build.openal.soft.done" value="true" />

--- a/make/scripts/adb-install-all-x86.sh
+++ b/make/scripts/adb-install-all-x86.sh
@@ -1,0 +1,4 @@
+#adb $* install ../../gluegen/build-android-x86/jogamp-android-launcher.apk
+#adb $* install ../../gluegen/build-android-x86/gluegen-rt-android-armeabi.apk
+adb $* install ../build-android-x86/jar/joal-android-x86.apk
+adb $* install ../build-android-x86/jar/joal-test-android.apk

--- a/make/scripts/adb-reinstall-all-x86.sh
+++ b/make/scripts/adb-reinstall-all-x86.sh
@@ -1,0 +1,5 @@
+sdir=`dirname $0`
+
+$sdir/adb-uninstall-all.sh $*
+$sdir/adb-install-all-x86.sh $*
+

--- a/make/scripts/make.joal.all.android-x86-cross.sh
+++ b/make/scripts/make.joal.all.android-x86-cross.sh
@@ -1,0 +1,104 @@
+#! /bin/sh
+
+SDIR=`dirname $0` 
+
+if [ -e $SDIR/../../../gluegen/make/scripts/setenv-build-jogl-x86_64.sh ] ; then
+    . $SDIR/../../../gluegen/make/scripts/setenv-build-jogl-x86_64.sh
+fi
+
+export NODE_LABEL=.
+
+export HOST_UID=jogamp
+# jogamp02 - 10.1.0.122
+export HOST_IP=10.1.0.122
+export HOST_RSYNC_ROOT=PROJECTS/JOGL
+
+export TARGET_UID=jogamp
+export TARGET_IP=panda02
+#export TARGET_IP=jautab03
+#export TARGET_IP=jauphone04
+export TARGET_ADB_PORT=5555
+# needs executable bit (probably su)
+export TARGET_ROOT=/data/projects
+export TARGET_ANT_HOME=/usr/share/ant
+
+echo ANDROID_HOME $ANDROID_HOME
+echo NDK_ROOT $NDK_ROOT
+
+if [ -z "$NDK_ROOT" ] ; then
+    #
+    # Generic android-ndk
+    #
+    if [ -e /usr/local/android-ndk ] ; then
+        NDK_ROOT=/usr/local/android-ndk
+    elif [ -e /opt-linux-x86/android-ndk ] ; then
+        NDK_ROOT=/opt-linux-x86/android-ndk
+    elif [ -e /opt/android-ndk ] ; then
+        NDK_ROOT=/opt/android-ndk
+    #
+    # Specific android-ndk-r8d
+    #
+    elif [ -e /usr/local/android-ndk-r8d ] ; then
+        NDK_ROOT=/usr/local/android-ndk-r8d
+    elif [ -e /opt-linux-x86/android-ndk-r8d ] ; then
+        NDK_ROOT=/opt-linux-x86/android-ndk-r8d
+    elif [ -e /opt/android-ndk-r8d ] ; then
+        NDK_ROOT=/opt/android-ndk-r8d
+    else 
+        echo NDK_ROOT is not specified and does not exist in default locations
+        exit 1
+    fi
+elif [ ! -e $NDK_ROOT ] ; then
+    echo NDK_ROOT $NDK_ROOT does not exist
+    exit 1
+fi
+export NDK_ROOT
+
+if [ -z "$ANDROID_HOME" ] ; then
+    if [ -e /usr/local/android-sdk-linux_x86 ] ; then
+        ANDROID_HOME=/usr/local/android-sdk-linux_x86
+    elif [ -e /opt-linux-x86/android-sdk-linux_x86 ] ; then
+        ANDROID_HOME=/opt-linux-x86/android-sdk-linux_x86
+    elif [ -e /opt/android-sdk-linux_x86 ] ; then
+        ANDROID_HOME=/opt/android-sdk-linux_x86
+    else 
+        echo ANDROID_HOME is not specified and does not exist in default locations
+        exit 1
+    fi
+elif [ ! -e $ANDROID_HOME ] ; then
+    echo ANDROID_HOME $ANDROID_HOME does not exist
+    exit 1
+fi
+export ANDROID_HOME
+
+export ANDROID_VERSION=9
+export SOURCE_LEVEL=1.6
+export TARGET_LEVEL=1.6
+export TARGET_RT_JAR=/opt-share/jre1.6.0_30/lib/rt.jar
+
+#export GCC_VERSION=4.4.3
+export GCC_VERSION=4.7
+HOST_ARCH=linux-x86
+export TARGET_TRIPLE=i686-linux-android
+export TOOLCHAIN_NAME=x86
+
+export NDK_TOOLCHAIN_ROOT=$NDK_ROOT/toolchains/${TOOLCHAIN_NAME}-${GCC_VERSION}/prebuilt/${HOST_ARCH}
+export TARGET_PLATFORM_ROOT=${NDK_ROOT}/platforms/android-${ANDROID_VERSION}/arch-x86
+
+# Need to add toolchain bins to the PATH. 
+export PATH_VANILLA=$PATH
+export PATH="$NDK_TOOLCHAIN_ROOT/$TARGET_TRIPLE/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/17.0.0:$PATH"
+
+export GLUEGEN_CPPTASKS_FILE=`pwd`/../../gluegen/make/lib/gluegen-cpptasks-android-x86.xml
+
+#export JUNIT_DISABLED="true"
+#export JUNIT_RUN_ARG0="-Dnewt.test.Screen.disableScreenMode"
+
+#export JOGAMP_JAR_CODEBASE="Codebase: *.jogamp.org"
+export JOGAMP_JAR_CODEBASE="Codebase: *.goethel.localnet"
+
+# BUILD_ARCHIVE=true \
+ant \
+    -Drootrel.build=build-android-x86 \
+    $* 2>&1 | tee -a make.joal-x86-cross.log
+

--- a/make/scripts/make.joal.all.sh
+++ b/make/scripts/make.joal.all.sh
@@ -7,3 +7,4 @@ $SDIR/make.joal.all.linux-armv6-cross.sh \
 && $SDIR/make.joal.all.linux-x86_64.sh \
 && $SDIR/make.joal.all.linux-x86.sh \
 && $SDIR/make.joal.all.android-armv6-cross.sh \
+&& $SDIR/make.joal.all.android-x86-cross.sh \


### PR DESCRIPTION
Hi,

I've added support for android x86 targets:
 - wrote an ant task to compile openal-soft to the right target, with neon and sse4.1 deactivated, sse and sse2 activated.
- added shell scripts to launch cross compilation of joal for x86 android targets.

This depends on https://github.com/sgothel/openal-soft/pull/1 and https://github.com/sgothel/gluegen/pull/24
