### PR TITLE
Proposed fix for bug_1280

### DIFF
--- a/src/java/com/jogamp/openal/util/WAVData.java
+++ b/src/java/com/jogamp/openal/util/WAVData.java
@@ -89,7 +89,8 @@ public final class WAVData {
      * @param bits
      * @param sampleRate
      * @param byteOrder
-     * @param stream An InputStream for the .WAV stream
+     * @param aIn An InputStream for the .WAV stream
+     * @param size Amount of data to load from buffer (or zero for all available)
      *
      * @return a WAVData object containing the audio data
      *
@@ -98,7 +99,7 @@ public final class WAVData {
      * @throws IOException If the file can no be found or some other IO error
      *                     occurs
      */
-    public static WAVData loadFromStream(InputStream aIn, final int initialCapacity, final int numChannels, final int bits, final int sampleRate, final ByteOrder byteOrder, final boolean loop)
+    public static WAVData loadFromStream(InputStream aIn, final int initialCapacity, final int numChannels, final int bits, final int sampleRate, final ByteOrder byteOrder, final boolean loop, int size)
       throws IOException {
         if( !(aIn instanceof BufferedInputStream) ) {
             aIn = new BufferedInputStream(aIn);
@@ -116,7 +117,9 @@ public final class WAVData {
             format = ALConstants.AL_FORMAT_STEREO16;
         }
         final ByteBuffer buffer = IOUtil.copyStream2ByteBuffer(aIn, initialCapacity);
-        final int size = buffer.limit();
+        if (size==0) {
+            size = buffer.limit();
+        }
 
         // Must byte swap in case endianess mismatch
         if ( bits == 16 && ByteOrder.nativeOrder() != byteOrder ) {

--- a/src/java/com/jogamp/openal/util/WAVLoader.java
+++ b/src/java/com/jogamp/openal/util/WAVLoader.java
@@ -123,6 +123,7 @@ public class WAVLoader {
 		    short sChannels = 0, sSampleSizeInBits = 0;
 		    long sampleRate = 0;
 		    long chunkLength = 0;
+            int dataLength = 0;
 
 			while (!foundData) {
 				final int chunkId = (int)bs.readUInt32(true /* bigEndian */);
@@ -150,6 +151,7 @@ public class WAVLoader {
 						throw new ALException("WAV fmt chunks must be before data chunks: "+bs);
 					}
 					foundData = true;
+                    dataLength = Bitstream.uint32LongToInt(chunkLength);
 					break;
 				default:
 					// unrecognized chunk, skips it
@@ -160,8 +162,8 @@ public class WAVLoader {
 			final int channels = sChannels;
 			final int sampleSizeInBits = sSampleSizeInBits;
 			final float fSampleRate = sampleRate;
-			return WAVData.loadFromStream(bs.getSubStream(), riffLenI, channels, sampleSizeInBits,
-					Math.round(fSampleRate), bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN, false);
+			return WAVData.loadFromStream(bs.getSubStream(), dataLength, channels, sampleSizeInBits,
+					Math.round(fSampleRate), bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN, false, dataLength);
 		} finally {
 			bs.close();
 		}

--- a/src/test/com/jogamp/openal/test/junit/ALutWAVLoaderTest.java
+++ b/src/test/com/jogamp/openal/test/junit/ALutWAVLoaderTest.java
@@ -41,19 +41,19 @@ public class ALutWAVLoaderTest extends UITestCase {
 
     @Test
     public void testWAVDataLoadStream() throws IOException {
-    	final WAVData wd0 = WAVData.loadFromStream(ResourceLocation.getTestStream0(), ResourceLocation.getTestStream0Size(), 1, 8, 22050, ByteOrder.LITTLE_ENDIAN, true);
+    	final WAVData wd0 = WAVData.loadFromStream(ResourceLocation.getTestStream0(), ResourceLocation.getTestStream0Size(), 1, 8, 22050, ByteOrder.LITTLE_ENDIAN, true, 0);
     	System.out.println("*** WAVData.loadFrom Stream0 size "+wd0.data.limit());
     	assertEquals(wd0.data.limit(), ResourceLocation.getTestStream0Size());
 
-        final WAVData wd1 = WAVData.loadFromStream(ResourceLocation.getTestStream1(), ResourceLocation.getTestStream1Size(), 2, 16, 44100, ByteOrder.BIG_ENDIAN, true);
+        final WAVData wd1 = WAVData.loadFromStream(ResourceLocation.getTestStream1(), ResourceLocation.getTestStream1Size(), 2, 16, 44100, ByteOrder.BIG_ENDIAN, true, 0);
         System.out.println("*** WAVData.loadFrom Stream1 size "+wd1.data.limit());
         assertEquals(wd1.data.limit(), ResourceLocation.getTestStream1Size());
 
-        final WAVData wd2 = WAVData.loadFromStream(ResourceLocation.getTestStream2(), ResourceLocation.getTestStream2Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true);
+        final WAVData wd2 = WAVData.loadFromStream(ResourceLocation.getTestStream2(), ResourceLocation.getTestStream2Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true, 0);
         System.out.println("*** WAVData.loadFrom Stream2 size "+wd2.data.limit());
         assertEquals(wd2.data.limit(), ResourceLocation.getTestStream2Size());
 
-        final WAVData wd3 = WAVData.loadFromStream(ResourceLocation.getTestStream3(), ResourceLocation.getTestStream3Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true);
+        final WAVData wd3 = WAVData.loadFromStream(ResourceLocation.getTestStream3(), ResourceLocation.getTestStream3Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true, 0);
         System.out.println("*** WAVData.loadFrom Stream3 size "+wd3.data.limit());
         assertEquals(wd3.data.limit(), ResourceLocation.getTestStream3Size());
 

--- a/src/test/com/jogamp/openal/test/manual/OpenALTest.java
+++ b/src/test/com/jogamp/openal/test/manual/OpenALTest.java
@@ -102,7 +102,7 @@ public class OpenALTest {
 
         // WAVData wd = WAVData.loadFromStream(ResourceLocation.getTestStream0(), ResourceLocation.getTestStream0Size(), 1, 8, 22050, ByteOrder.LITTLE_ENDIAN, true);
         // WAVData wd = WAVData.loadFromStream(ResourceLocation.getTestStream1(), ResourceLocation.getTestStream1Size(), 2, 16, 44100, ByteOrder.BIG_ENDIAN, true);
-        final WAVData wd = WAVData.loadFromStream(ResourceLocation.getTestStream2(), ResourceLocation.getTestStream2Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true);
+        final WAVData wd = WAVData.loadFromStream(ResourceLocation.getTestStream2(), ResourceLocation.getTestStream2Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true, 0);
         // WAVData wd = WAVData.loadFromStream(ResourceLocation.getTestStream3(), ResourceLocation.getTestStream3Size(), 2, 16, 44100, ByteOrder.LITTLE_ENDIAN, true);
         System.out.println("*** size "+wd.data.limit());
 


### PR DESCRIPTION
Ensure that only the size of sample data chunk is loaded, rather than entire remaining buffer. Copes with WAV files that have metadata appended to the end after the data RIFF chunk.

Note: no additional unit test has been added as I do not (yet) have a suitable WAV file that can be included in the distribution
